### PR TITLE
Fix range for brighterscript peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "vscode-languageserver-types": "^3.17.3"
   },
   "peerDependencies": {
-    "brighterscript": "0.65.x"
+    "brighterscript": ">= 0.65.0 < 1"
   },
   "peerDependenciesMeta": {
     "brighterscript": {


### PR DESCRIPTION
The latest brighterscript release bumped the minor version to 0.67. The peer dependencies in this project prevent it from properly installing even though v0.67.0 totally still works. I have updated the peerDependency to support the same minimum version, the whole way to v1 (exclusive). 