### PR TITLE
fix: guard against undefined children in validateXmlFile

### DIFF
--- a/src/SGXmlValidator.ts
+++ b/src/SGXmlValidator.ts
@@ -20,7 +20,7 @@ export class SGXmlValidator {
 
     validateXmlFile(event: OnFileValidateEvent<BscFile>) {
         const file = event.file as XmlFile;
-        const diags = file?.ast?.component?.children.children.flatMap((child) => {
+        const diags = file?.ast?.component?.children?.children?.flatMap((child) => {
             return this.validateComponent(child).map(diag => {
                 return {
                     ...diag,

--- a/src/XmlProvider.spec.ts
+++ b/src/XmlProvider.spec.ts
@@ -13,6 +13,14 @@ function componentWithChildren(children: string) {
 </component>`;
 }
 
+function componentWithoutChildren() {
+  return `<component name="Test" extends="Group">
+  <interface>
+    <field id="someField" type="string" />
+  </interface>
+</component>`;
+}
+
 describe('XmlProvider class', () => {
   let program: Program;
   beforeEach(async function () {
@@ -127,5 +135,60 @@ describe('XmlProvider class', () => {
     expect(completions.find((e) => e.label === 'rowItemSize')).to.not.be
       .undefined;
     expect(completions.find((e) => e.label === 'id')).to.not.be.undefined;
+  });
+});
+
+describe('SGXmlValidator', () => {
+  let program: Program;
+
+  beforeEach(async function () {
+    const builder = new ProgramBuilder();
+    const options = JSON.parse(readFileSync('sample/bsconfig.json').toString());
+
+    builder.plugins.add(new BscXmlPlugin());
+    await builder.run({
+      ...options,
+      cwd: join(__dirname, '../sample'),
+      validate: false,
+    });
+    program = builder.program;
+  });
+
+  afterEach(() => {
+    program.dispose();
+  });
+
+  it('does not throw or produce diagnostics for a component with no <children> block', () => {
+    const path = 'components/TestNode.xml';
+    program.setFile(path, componentWithoutChildren());
+    expect(() => program.validate()).to.not.throw();
+    const diags = program.getDiagnostics().filter(
+      (d) => (d as any).file?.pkgPath?.includes('TestNode')
+    );
+    expect(diags).to.have.length(0);
+  });
+
+  it('produces no diagnostics for a valid component with a <children> block', () => {
+    const path = 'components/TestNode.xml';
+    program.setFile(path, componentWithChildren('<LayoutGroup layoutDirection="vert" />'));
+    program.validate();
+    const diags = program.getDiagnostics().filter(
+      (d) => (d as any).file?.pkgPath?.includes('TestNode')
+    );
+    expect(diags).to.have.length(0);
+  });
+
+  it('produces a BSSG2001 warning for an attribute name case mismatch inside <children>', () => {
+    const path = 'components/TestNode.xml';
+    // layoutdirection is the wrong case, layoutDirection is correct
+    program.setFile(path, componentWithChildren('<LayoutGroup layoutdirection="vert" />'));
+    program.validate();
+    const diags = program.getDiagnostics().filter(
+      (d) => (d as any).file?.pkgPath?.includes('TestNode')
+    );
+    expect(diags).to.have.length.at.least(1);
+    expect(diags[0].code).to.equal('SG2001');
+    expect(diags[0].message).to.include('layoutdirection');
+    expect(diags[0].message).to.include('layoutDirection');
   });
 });


### PR DESCRIPTION
### Problem

`SGXmlValidator.validateXmlFile` accesses `file.ast.component.children.children.flatMap(...)` without guarding against `children` being `undefined`. In BrighterScript's XML AST, `component.children` is only populated when the component XML actually declares a `<children>` block. Any component file without one (interface-only components, task nodes, etc.) causes a `TypeError: Cannot read properties of undefined (reading 'children')` to be thrown inside `onFileValidate`.

BrighterScript's `PluginInterface` catches the unhandled exception and logs it to the console, but silently aborts validation for that file — meaning no diagnostics are produced for any component missing a `<children>` block, regardless of what other issues exist.

Discovered while integrating this plugin into [JellyRock](https://github.com/jellyrock/jellyrock) via Renovate ([jellyrock/jellyrock#347](https://github.com/jellyrock/jellyrock/pull/347)). JellyRock has ~170 XML component files, the majority of which have no `<children>` block, so every one was crashing the plugin silently.

```
[09:20:47:549 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:549 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:550 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:550 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:550 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:550 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:550 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:551 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:551 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:551 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:551 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:551 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:551 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:551 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:552 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:552 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:552 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:552 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:552 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:553 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:553 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:553 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:553 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:554 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:554 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:554 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:556 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:556 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:557 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:557 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:557 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:557 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:557 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:558 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:558 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:558 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:558 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:558 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:558 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:559 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:559 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:559 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:560 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:561 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:561 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:561 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:562 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:562 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:562 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:562 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:562 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:563 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:563 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:563 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:563 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:563 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:564 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:47:564 PM] Error when calling plugin bsc-xml-plugin.onFileValidate: TypeError: Cannot read properties of undefined (reading 'children')
    at SGXmlValidator.validateXmlFile (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/SGXmlValidator.js:18:189)
    at BscXmlPlugin.onFileValidate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript-xml-plugin/dist/index.js:31:38)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:28:38
    at Logger.time (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/@rokucommunity/logger/dist/Logger.js:373:20)
    at PluginInterface.emit (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/PluginInterface.js:27:33)
    at Object.func (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:580:30)
    at Sequencer.runSync (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/common/Sequencer.js:99:39)
    at Program.validate (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/Program.js:622:30)
    at ProgramBuilder.validateProject (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:473:22)
    at ProgramBuilder._runOnce (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:330:22)
    at /home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:249:25
    at async ProgramBuilder.run (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/ProgramBuilder.js:153:13)
    at async main (/home/charlie/PROJECTS/JellyRock/jellyrock/node_modules/brighterscript/dist/cli.js:71:13)
[09:20:48:078 PM] Validating project finished. (726.450ms)
```

### Fix

Extend optional chaining through both `.children` accesses:

```diff
- const diags = file?.ast?.component?.children.children.flatMap((child) => {
+ const diags = file?.ast?.component?.children?.children?.flatMap((child) => {
```

The expression now short-circuits to `undefined` when no `<children>` block is present, which the existing `|| []` fallback already handles correctly.

### Tests

Added a dedicated `SGXmlValidator` describe block with three cases:

- **No crash, no diagnostics** for a component with no `<children>` block — regression test for this fix
- **No diagnostics** for a valid component with a `<children>` block — confirms validation still runs normally
- **`SG2001` warning produced** for an attribute name case mismatch inside `<children>` — confirms diagnostic output is correct